### PR TITLE
[macos] Fix hammerspoon issue of language switching

### DIFF
--- a/macos/hammerspoon/input.lua
+++ b/macos/hammerspoon/input.lua
@@ -18,7 +18,7 @@ local app2Ime = {
   {'/System/Library/CoreServices/Spotlight.app', 'English'},
   {'/Applications/System Preferences.app', 'English'},
   {'/Applications/Visual Studio Code.app', 'English'},
-  {'/Applications/Wechat.app', 'Chinese'},
+  {'/Applications/WeChat.app', 'Chinese'},
 }
 
 function updateFocusAppInputMethod()


### PR DESCRIPTION
The app path has a casing issue and caused language switching to not function.